### PR TITLE
Added test for confusing -m and -M options

### DIFF
--- a/tests/test/data/confused_mail_options.pbs
+++ b/tests/test/data/confused_mail_options.pbs
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+#PBS -N my_job
+#PBS -A lp_qlint
+#PBS -l nodes=2:ppn=4
+#PBS -l pmem=4gb
+#PBS -lwalltime=72:00:00
+#PBS -lqos=debugging
+#PBS -j oe
+#PBS -k o
+#PBS -M ae
+
+cd $PBS_O_WORKDIR
+echo "hello world!"
+

--- a/tests/test/script_parser_test.py
+++ b/tests/test/script_parser_test.py
@@ -188,3 +188,14 @@ class PbsScriptParserTest(unittest.TestCase):
         with open(file_name, 'r') as pbs_file:
             parser.parse_file(pbs_file)
         self.assertEquals(len(event_names), len(parser.events))
+
+    def test_confused_mail_options(self):
+        file_name = 'data/confused_mail_options.pbs'
+        event_names = ['invalid_mail_address']
+        parser = PbsScriptParser(self._config, self._event_defs)
+        with open(file_name, 'r') as pbs_file:
+            parser.parse_file(pbs_file)
+        self.assertEquals(len(event_names), len(parser.events))
+        for event in parser.events:
+            self.assertTrue(event['id'] in event_names)
+        self.assertEquals(len(event_names), parser.nr_warnings)


### PR DESCRIPTION
Test indicates that confusion of -m and -M option should result in an invalid mail address warning.