### PR TITLE
Add qstat functionality

### DIFF
--- a/tests/test/qstat_progress_test.py
+++ b/tests/test/qstat_progress_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+'''module to test the vsc.pbs.qstat.QstatParser parser for progress information'''
+
+from datetime import datetime
+import json, unittest
+from vsc.pbs.qstat import QstatParser
+
+class QstatProgressTest(unittest.TestCase):
+    '''Tests for the qstat -f output parser'''
+
+    def setUp(self):
+        conf_file_name = '../../conf/config.json'
+        with open(conf_file_name, 'r') as conf_file:
+            self._config = json.load(conf_file)
+        self._config['cluster_db'] = 'data/cluster.db'
+        self._config['mock_balance'] = 'data/gbalance_new.txt'
+
+    def test_parsing(self):
+        file_name = 'data/qstat_f_out.txt'
+        test_jobs = [0, 82, 89]
+        job_id = ['50011943.tier2-p-moab-2.icts.hpc.kuleuven.be',
+                  '50317784.tier2-p-moab-2.tier2.hpc.kuleuven.be',
+                  '50318782.tier2-p-moab-2.tier2.hpc.kuleuven.be']
+        job_state = ['Q', 'R', 'C']
+        job_queue_times = ['Tue Jul 31 11:59:59 2018',
+                           'Fri Apr 17 16:06:19 2020',
+                           'Sun Apr 19 11:25:17 2020',]
+        job_start_times = [None,
+                           'Sat Apr 18 15:42:00 2020',
+                           'Mon Apr 20 14:32:53 2020']
+        parser = QstatParser(self._config)
+        with open(file_name, 'r') as qstat_file:
+            jobs = parser.parse_file(qstat_file)
+        for i in range(len(test_jobs)):
+            self.assertEqual(job_id[i], jobs[test_jobs[i]].job_id)
+            if job_start_times[i] is not None:
+                delta = (datetime.strptime(job_start_times[i], '%c') -
+                         datetime.strptime(job_queue_times[i], '%c'))
+            else:
+                delta = (datetime.now() - datetime.strptime(job_queue_times[i], '%c'))
+            self.assertAlmostEqual(delta.total_seconds(), jobs[test_jobs[i]].time_in_queue, places=0)

--- a/tests/test/qstat_progress_test.py
+++ b/tests/test/qstat_progress_test.py
@@ -28,6 +28,8 @@ class QstatProgressTest(unittest.TestCase):
         job_start_times = [None,
                            'Sat Apr 18 15:42:00 2020',
                            'Mon Apr 20 14:32:53 2020']
+        job_run_times = [0, 515627, 345605, ]
+        job_remaining_times = [1, 518400 - 515627, 0]
         parser = QstatParser(self._config)
         with open(file_name, 'r') as qstat_file:
             jobs = parser.parse_file(qstat_file)
@@ -38,4 +40,8 @@ class QstatProgressTest(unittest.TestCase):
                          datetime.strptime(job_queue_times[i], '%c'))
             else:
                 delta = (datetime.now() - datetime.strptime(job_queue_times[i], '%c'))
-            self.assertAlmostEqual(delta.total_seconds(), jobs[test_jobs[i]].time_in_queue, places=0)
+            self.assertAlmostEqual(delta.total_seconds(),
+                                   jobs[test_jobs[i]].time_in_queue, places=0)
+            self.assertEqual(job_run_times[i], jobs[test_jobs[i]].walltime_used)
+            self.assertEqual(job_remaining_times[i],
+                             jobs[test_jobs[i]].walltime_remaining)

--- a/vsc/pbs/job.py
+++ b/vsc/pbs/job.py
@@ -1,5 +1,6 @@
 '''module to represent and manipulate PBS jobs'''
 
+from datetime import datetime
 import operator
 import os
 
@@ -313,6 +314,44 @@ class PbsJob(object):
             return self.events[-1].time_stamp
         else:
             return None
+
+    @property
+    def queue_time(self):
+        '''return queue time as reported by qstat'''
+        try:
+            return self._queue_time
+        except:
+            return None
+
+    @queue_time.setter
+    def queue_time(self, value):
+        '''set queue time as reported by qstat'''
+        if type(value) == str:
+            self._queue_time = datetime.strptime(value, '%c')
+        else:
+            self._queue_time = value
+
+    @property
+    def start_time(self):
+        '''return start time as reported by qstat'''
+        try:
+            return self._start_time
+        except:
+            return None
+    @start_time.setter
+    def start_time(self, value):
+        '''set start time as reported by qstat'''
+        if type(value) == str:
+            self._start_time = datetime.strptime(value, '%c')
+        else:
+            self._start_time = value
+
+    @property
+    def time_in_queue(self):
+        if self.state == 'Q':
+            return (datetime.now() - self.queue_time).total_seconds()
+        else:
+            return (self.start_time - self.queue_time).total_seconds()
 
     def attrs_to_str(self):
         '''return job attributes as a string, mainly for debug purposes'''

--- a/vsc/pbs/job.py
+++ b/vsc/pbs/job.py
@@ -353,6 +353,23 @@ class PbsJob(object):
         else:
             return (self.start_time - self.queue_time).total_seconds()
 
+    @property
+    def walltime_used(self):
+        '''return the walltime already used by the job, 0 if queued'''
+        if self.state == 'Q':
+            return 0
+        else:
+            return self.resource_used('walltime')
+
+    @property
+    def walltime_remaining(self):
+        ''' return walltime remaining for a job, requested walltime if queued'''
+        if self.state == 'Q':
+            return self.resource_spec('walltime')
+        else:
+            delta = self.resource_spec('walltime') - self.resource_used('walltime')
+            return delta if delta >= 0 else 0
+
     def attrs_to_str(self):
         '''return job attributes as a string, mainly for debug purposes'''
         attr_str = ''

--- a/vsc/pbs/qstat.py
+++ b/vsc/pbs/qstat.py
@@ -79,6 +79,10 @@ class QstatParser(object):
                 job.exec_host = exec_host
             elif line.startswith('Resource_List.partition ='):
                 job.partition = self._get_value(line)
+            elif line.startswith('qtime = '):
+                job.queue_time = self._get_value(line)
+            elif line.startswith('start_time = '):
+                job.start_time = self._get_value(line)
         job.add_resource_specs(resource_specs)
         job.add_resources_used(resources_used)
         return job


### PR DESCRIPTION
You can now retrieve time_in_queue, walltime_used, walltime_remaining for job objects generated by  the qstat parser.